### PR TITLE
Workaround for server stealing focus on Linux

### DIFF
--- a/instant-markdown-d
+++ b/instant-markdown-d
@@ -5,6 +5,7 @@ var MarkdownIt = require('markdown-it');
 var hljs = require('highlight.js');
 var server = require('http').createServer(httpHandler),
     exec = require('child_process').exec,
+    fs = require('fs'),
     io = require('socket.io').listen(server),
     send = require('send'),
     server,
@@ -97,5 +98,13 @@ if (process.platform.toLowerCase().indexOf('darwin') >= 0){
   exec('open -g http://localhost:8090', function(error, stdout, stderr){});
 }
 else {  // assume unix/linux
-  exec('xdg-open http://localhost:8090', function(error, stdout, stderr){});
+  exec('xdotool getactivewindow', function(error, stdout, stderr) {
+    if (error) {
+      console.error(error.message);
+    }
+    var activeWindowId = stdout;
+    exec('xdg-open http://localhost:8090', function(error, stdout, stderr) {
+      exec('xdotool windowfocus ' + activeWindowId);
+    });
+  });
 }


### PR DESCRIPTION
Requires xdotool to be installed for the workaround to work, but it's not
necessary for the operation of the server.

Fixes suan/vim-instant-markdown#37.
