### PR TITLE
ignore the YAML meta block when rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ let socket = io('http://'+ window.location.host +'/');
 socket.on('connect', function () {
   setDisconnected(false);
   socket.on('newContent', function(newHTML) {
+    var s = "</h2>\n"
+    var idx = newHTML.indexOf(s)
+    newHTML = newHTML.substring(idx+s.length)
     document.querySelector(".markdown-body").innerHTML = newHTML;
 
     // scroll to the hyperlink with id="marker"


### PR DESCRIPTION
This CL trims the YAML meta block string prefix.

The YAML meta block `---^@layout:post....---`will be rendered in this way `<hr>\n<h2>....</h2>\n`.
So we can easily locate this substring "</h2>\n" and trim the prefix before rendering the newHTML.

Closes #93 