### PR TITLE
feat: ignore the YAML meta block when rendering

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -58,7 +58,7 @@ jobs:
         CI: true
 
     - name: Install mamba
-      uses: mamba-org/provision-with-micromamba@v10
+      uses: mamba-org/provision-with-micromamba@v12
       with:
         environment-file: tests/environment.yml
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "markdown-it": "^8.4.2",
     "markdown-it-mathjax": "^2.0.0",
     "markdown-it-task-lists": "^2.1.1",
+    "markdown-it-front-matter": "^0.2.3",
     "markdown-it-textual-uml": "^0.1.3",
     "mathjax": "^2.7.5",
     "mathjax-node-page": "^3.0.2",

--- a/src/cli.js
+++ b/src/cli.js
@@ -31,7 +31,8 @@ const MarkdownIt = require('markdown-it'),
 
 const mjpage = require('mathjax-node-page').mjpage;
 const taskLists = require('markdown-it-task-lists');
-
+const frontMatter = require('markdown-it-front-matter');
+ 
 if (argv.version || argv.debug) {
   const version= require('./version');
   console.log(`instant-markdown-d version: v${version}`);
@@ -81,7 +82,7 @@ let md = new MarkdownIt({
       return str;
     }
   }
-}).use(taskLists);
+}).use(taskLists, {enabled: true}).use(frontMatter, function(fm){});
 
 if (argv.mathjax) md.use(require('markdown-it-mathjax')());
 if (argv.mermaid) md.use(require('markdown-it-textual-uml'));


### PR DESCRIPTION
This CL trims the YAML meta block string prefix.

This CL uses another markdown-it-front-matter to determine how to render the front matter part,
which just ignores it so far.

And I add `{enabled: true}` to markdown-it-tasklists to render checkboxes.

Closes #94 